### PR TITLE
Batch updates with rafz

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "webpack": "^4.43.0"
   },
   "dependencies": {
-    "debounce": "^1.2.0"
+    "debounce": "^1.2.0",
+    "rafz": "^0.1.14"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5502,6 +5502,11 @@ querystring@0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
+rafz@^0.1.14:
+  version "0.1.14"
+  resolved "https://registry.yarnpkg.com/rafz/-/rafz-0.1.14.tgz#164f01cf7cc6094e08467247ef351ef5c8d278fe"
+  integrity sha512-YiQkedSt1urYtYbvHhTQR3l67M8SZbUvga5eJFM/v4vx/GmDdtXlE2hjJIyRjhhO/PjcdGC+CXCYOUA4onit8w==
+
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"


### PR DESCRIPTION
When multiple components are using react-use-measure and a scroll event occurs, multiple react updates are executed serially. 

I've got 9 components on screen which use react-use-measure, so a scroll event takes about `~2*9 =18ms` to finish rendering. Shown below is 3 of the updates.

![image](https://user-images.githubusercontent.com/13504878/101275056-b3051480-37f2-11eb-884b-922f3cf3acc0.png)

I use `rafz` for similar problems already (thank you by the way!), so this seemed like an elegant solution. It reduces the render time for my 9 components to `~9ms`

![image](https://user-images.githubusercontent.com/13504878/101274932-e7c49c00-37f1-11eb-9fa8-f35f44093c27.png)

I don't think this substantially changes the API for those not using `rafz` so I would hope it's not a breaking change? For those using it, they can opt in to batch their renders.

Thanks!