### PR TITLE
Expose areBoundsEqual comparator as a prop

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,8 @@ type Options = {
   scroll?: boolean
   // You can optionally inject a resize-observer polyfill
   polyfill?: { new (cb: ResizeObserverCallback): ResizeObserver }
+  // You can optionally provide a custom comparator to ignore certain updates to the RectReadOnly
+  areBoundsEqual?: (a: RectReadOnly, b: RectReadOnly) => boolean
 }
 
 useMeasure(


### PR DESCRIPTION
Following discussion on discord regarding unnecessary re-renders, this PR exposes the `areBoundsEqual` comparator to the developer, allowing them to pass for example:

```
areBoundsEqual = (a: RectReadOnly, b: RectReadOnly): boolean => a.width === b.width && a.height === b.height
```

Which would ignore position updates and only update on resizes.

