### PR TITLE
Remove conditional CJS module export

### DIFF
--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -180,11 +180,3 @@ const keys: (keyof RectReadOnly)[] = ['x', 'y', 'top', 'bottom', 'left', 'right'
 const areBoundsEqual = (a: RectReadOnly, b: RectReadOnly): boolean => keys.every((key) => a[key] === b[key])
 
 export default useMeasure
-
-if (
-  typeof module !== 'undefined' &&
-  Object.getOwnPropertyDescriptor &&
-  Object.getOwnPropertyDescriptor(module, 'exports')!.writable
-) {
-  module.exports = useMeasure
-}


### PR DESCRIPTION
If react-use-measure is bundled in another library which uses it, the conditional CSJ module export can override the default export of this library.

I have a library which I distribute as ES module. The bundle resulted in something like 

```javascript
const MyReactComponent = () => {
    // My component code
}

export default MyReactComponent;

// react-use-measure code

if (
    typeof module !== 'undefined' &&
    Object.getOwnPropertyDescriptor &&
    Object.getOwnPropertyDescriptor(module, 'exports')!.writable
) {
    module.exports = useMeasure
}
```

When using this/my library in a project and you try to run tests, Jest will transform this to a CJS module, since Jest can only work with those. But the resulting code now suddenly overrides the default export of the library.

```javascript
const MyReactComponent = () => {
    // My component code
}

module.exports = MyReactComponent;

// react-use-measure code

if (
    typeof module !== 'undefined' &&
    Object.getOwnPropertyDescriptor &&
    Object.getOwnPropertyDescriptor(module, 'exports')!.writable
) {
    module.exports = useMeasure
}
```

With ES modules, the conditional `module.exports = useMeasure` has no effect. But if that ES module is converted to a CJS module, the code now overrides the default export of the library which bundles react-use-measure.

I hope my explanation is somewhat understandable. Is there a reason that you have that conditional export in the source of react-use-measure? If react-use-measure is transpiled to a CJS module an appropriate export will be generated anyway.