### PR TITLE
Fix: Switch to default import for debounce

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "semi": false,
     "trailingComma": "es5",
     "singleQuote": true,
-    "jsxBracketSameLine": true,
+    "bracketSameLine": true,
     "tabWidth": 2,
     "printWidth": 120
   },

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef, useMemo } from 'react'
-import { debounce as createDebounce } from 'debounce'
+import createDebounce from 'debounce'
 
 declare type ResizeObserverCallback = (entries: any[], observer: ResizeObserver) => void
 declare class ResizeObserver {


### PR DESCRIPTION
### Summary

When run in the browser or ESM node setup, the import of `debounce` fails . This has likely been working this whole time due to "bundler magic" in webpack. By switching to a default import the import should no longer fail in these ESM setups.



<img width="327" alt="debounce exports" src="https://user-images.githubusercontent.com/4625978/143595527-b0f120a2-73b3-4129-af21-b2644c6f6646.png">

https://github.com/component/debounce/blob/8be734c4b5b5a58a517f2441e0d90242a4a564cd/index.js#L67-L70


### Extra Context
Node's ESM support is stricter with how CJS dependencies are imported/handled than bundlers have been traditionally (they do "magic") so we need to update the import of debounce to import the default export to properly follow the spec as one cannot import named exports from CJS dependencies in an ESM module under node.


### Repro
<img width="765" alt="Screenshot 2021-11-26 at 08 38 08" src="https://user-images.githubusercontent.com/4625978/143589313-964b63d3-6425-45f8-8fea-0334b33ba007.png">

[JSPM Sandbox Link](https://jspm.org/sandbox#H4sIAAAAAAAAA5VVXXPTOhB9769YzAsftRSnfJSQdFJKYSiEYUjD5T4q8iZWsSUjyYSU4b+zlpO0NcUMD4lH2qOzZ4+k1fBOaqRflwiZL/KjveH2gyI92gMYFugFyExYh34UVX4RH0Yh4JXP8Wimwzcd8ma8W6JFgaPom8JVaayPQBrtURPFSqU+G6X4TUmMw2AflFZeiTx2UuQ4SijBkDcKhnOTrgPrnTimD8DZ9MMEXqNGK7yx8Kao+WEiyhA9TZWH2cd3A6rHl27A+XILZReuLJgy/O6s/yn7//WLLy8nPbueXp5NZ0kmT7K357NV1ZsenL09Ld8nM/7u/NR4efHy8+TZ8eVkeXz8tffZlyfLY8oUx0GUk1aVHmoDR5EKUgpRBoN+BD2bSRcNNhM0NbYopI99ZhH5Qs3RUjTa6RU7obosBr+Dx09Zj/V7PFXO82vROEQZuoIIopDs534jwklT4g0Nt2S7FiZAinNTaYkd0raQccL6LOFKp/i9Tr1/xbIQzscpYhnj10rkHWQt5PiAJezgVk4zv0CqWTinlrqD8QZu/Ij4btcYLOzgCfFxElzndG7ZH0niAu0SY4sL9ze+a1CyL2Gb7eymt0i3SKq888C0oWOS/eSvyiuHJEm4ynbt+G/Ycf9K+wrnLWonM0yrbrk7TK2zy+EdkHsrpNLLfyXdLGvRhqvTQRXiRJMcPKZC55XKUx7mWGHqFC262hs6cdh1oHYY2vkee9S415QsL1yL8LJyXui0g26DoBvzhD3mdP2vTvmG5ufe9r/+DXnTteomtWmscDqFSSgHppkq3GDbVqmZOShNvl6oPIcF9dumagdza1YOrYOV8pmpPKhrK1xVhsE9Qavwu0TqkSeZNQXC4bOH91vdU7i1luCsHP2pRHRxkzd2tbx6O/rssDGuFWOF0nXpIK1xzli1VHoUCW30ujCVi47a5d9o4Q1T6N+wregBCYTzestf1Q0WFlTHrU38ecMIwDn8Z5VHMkPpjWP0AKb0yKLFfSAbiVKAw1LQ04RA7mIwkiYjMiIC4b1V84piRoPPcMvSqGUhDd1wZ+gE5mZ570rf/ec39njImxeUHtTwsv8CUu3e+/EHAAA=)

