### PR TITLE
chore: add website & repository property for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,6 @@
       "pre-commit": "pretty-quick"
     }
   },
-  "repository": {	
-    "type": "git",
-    "url": "https://github.com/pmndrs/react-use-measure.git"
-  },
   "prettier": {
     "semi": false,
     "trailingComma": "es5",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "module": "./dist/web.js",
   "types": "./types/index.d.ts",
   "sideEffects": false,
+  "website": "https://github.com/pmndrs/react-use-measure",
+  "repository": "https://github.com/pmndrs/react-use-measure",
   "scripts": {
     "prebuild": "rimraf dist && npm run typegen",
     "build": "rollup -c",


### PR DESCRIPTION
I had trouble finding the github repo. since the google search returns the npm site first, it would be nice to have a github link info in package.json