### PR TITLE
Force a refresh when setting ref

### DIFF
--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -150,6 +150,7 @@ function useMeasure(
     state.current.element = node
     state.current.scrollContainers = findScrollContainers(node)
     addListeners()
+    forceRefresh()
   }
 
   // add general event listeners


### PR DESCRIPTION
This causes the first measurements to be calculated sooner since before this change the measurements don't take place until the first scroll event which can produce a noticeable flash. This does not completely fix the flash for all situations, but it reduces the length of the flash and in some cases fixes it altogether.