### PR TITLE
fix: make react-dom optional peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,11 @@
     "react": ">=16.13",
     "react-dom": ">=16.13"
   },
+  "peerDependenciesMeta": {
+    "react-dom": {
+      "optional": true
+    }
+  },
   "scripts": {
     "postinstall": "npx playwright install",
     "dev": "vite",


### PR DESCRIPTION
Makes `react-dom` an optional peer dep in case the view is produced by something else. Related: #7.