### PR TITLE
fix(types): interop default export

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,7 +37,11 @@ export default vite.defineConfig({
       name: 'vite-tsc',
       generateBundle(options) {
         const ext = options.format === 'cjs' ? 'cts' : 'ts'
-        this.emitFile({ type: 'asset', fileName: `index.d.${ext}`, source: `export * from '../src/index.ts'` })
+        this.emitFile({
+          type: 'asset',
+          fileName: `index.d.${ext}`,
+          source: `import useMeasure from '../src/index.ts';export * from '../src/index.ts';export = useMeasure;`,
+        })
       },
     },
     {


### PR DESCRIPTION
Interopts the default export so it is callable in some TypeScript configurations.